### PR TITLE
add SQS queue to limit re-crawl vector

### DIFF
--- a/redshift_spectrum_crossaccount/target_aws_account/glue.tf
+++ b/redshift_spectrum_crossaccount/target_aws_account/glue.tf
@@ -29,8 +29,13 @@ resource "aws_glue_crawler" "external_tables" {
     delete_behavior = "DELETE_FROM_DATABASE"
   }
 
+  recrawl_policy {
+    recrawl_behavior = "CRAWL_EVENT_MODE"
+  }
+
   s3_target {
-    path = "s3://${aws_s3_bucket.external_tables.bucket}/${each.value}/"
+    path            = "s3://${aws_s3_bucket.external_tables.bucket}/${each.value}/"
+    event_queue_arn = aws_sqs_queue.external_tables_crawler_bucket_notifications[each.value].arn
   }
 
   tags = {

--- a/redshift_spectrum_crossaccount/target_aws_account/glue_iam.tf
+++ b/redshift_spectrum_crossaccount/target_aws_account/glue_iam.tf
@@ -65,6 +65,33 @@ data "aws_iam_policy_document" "external_tables_crawler_access" {
     ]
   }
 
+  statement {
+    sid = "ListQueues"
+    actions = [
+      "sqs:ListQueues",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    sid = "ReadS3NotificationsFromRelevantQueue"
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ListDeadLetterSourceQueues",
+      "sqs:ChangeMessageVisibility",
+      "sqs:PurgeQueue",
+      "sqs:ReceiveMessage",
+      "sqs:GetQueueAttributes",
+      "sqs:ListQueueTags",
+      "sqs:SetQueueAttributes",
+    ]
+
+    resources = [
+      aws_sqs_queue.external_tables_crawler_bucket_notifications[each.value].arn,
+    ]
+  }
 }
 
 resource "aws_iam_policy" "external_tables_crawler_access" {

--- a/redshift_spectrum_crossaccount/target_aws_account/glue_sqs.tf
+++ b/redshift_spectrum_crossaccount/target_aws_account/glue_sqs.tf
@@ -1,0 +1,53 @@
+data "aws_iam_policy_document" "external_tables_crawler_bucket_notifications" {
+  provider = aws.glue_account
+
+  for_each = toset(var.tables_categories)
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = ["*"]
+
+    condition {
+      test     = "ArnEquals"
+      variable = "aws:SourceArn"
+      values   = [aws_sns_topic.external_tables_bucket_notifications.arn]
+    }
+  }
+
+}
+
+resource "aws_sqs_queue" "external_tables_crawler_bucket_notifications" {
+  provider = aws.glue_account
+
+  for_each = toset(var.tables_categories)
+  name     = local.external_tables_crawler_names[each.value]
+  policy   = data.aws_iam_policy_document.external_tables_crawler_bucket_notifications[each.value].json
+}
+
+resource "aws_sns_topic_subscription" "external_tables_crawler_bucket_notifications" {
+  provider = aws.glue_account
+
+  for_each            = toset(var.tables_categories)
+  topic_arn           = aws_sns_topic.external_tables_bucket_notifications.arn
+  protocol            = "sqs"
+  endpoint            = aws_sqs_queue.external_tables_crawler_bucket_notifications[each.value].arn
+  filter_policy_scope = "MessageBody"
+  filter_policy = jsonencode({
+    "Records" : {
+      "s3" : {
+        "object" : {
+          "key" : [
+            { "prefix" : "${each.value}/" }
+          ]
+        }
+      }
+    }
+  })
+}

--- a/redshift_spectrum_crossaccount/target_aws_account/trigger_crawler_lambda/lambda.py
+++ b/redshift_spectrum_crossaccount/target_aws_account/trigger_crawler_lambda/lambda.py
@@ -5,7 +5,8 @@ def trigger_crawler(event, context):
 
     environment = os.environ['ENVIRONMENT']
     crawler_name_prefix = os.environ['CRAWLER_NAME_PREFIX']
-    object_key = event['Records'][0]['s3']['object']['key']
+    message = json.loads(event['Records'][0]['Sns']['Message'])
+    object_key = message['Records'][0]['s3']['object']['key']
     folder_pattern = re.compile('.*/$')
     if folder_pattern.match(object_key):
         print('Skip: Folder creation event')


### PR DESCRIPTION
- Add SNS topic to fan out S3 events to Crawlers' SQS queues and to the Lambda
- modify Lambda to work with a new format of the event
- modify crawlers definition to read from  SQS queue
- finalize README.md